### PR TITLE
Increase queue processing time

### DIFF
--- a/tripal_elasticsearch.module
+++ b/tripal_elasticsearch.module
@@ -310,7 +310,7 @@ function tripal_elasticsearch_cron_queue_info(){
     $queues['elastic_queue_'.$n] = array(
       'worker callback' => 'elasticindexing_queue_item',
       //'time' => 60 * 60 * 2,  ## the amount of time drupal spends on calling the worker function.
-      'time' => 30,
+      'time' => 115,
     );
   }
 


### PR DESCRIPTION
Hi!
As within the docker-tripal containers indexing tasks are scheduled every 2 minutes, I made this little patch no our server to avoid wasting too much time between each task.
I propose this here in case 115 could be the new default value, feel free to close if you prefer to stay at 30
Cheers