### PR TITLE
Fix issue with gene search

### DIFF
--- a/includes/tripal_elasticsearch.gene_search.form.inc
+++ b/includes/tripal_elasticsearch.gene_search.form.inc
@@ -133,8 +133,8 @@ function tripal_elasticsearch_gene_search_form($form, &$form_state, $local = TRU
  */
 function tripal_elasticsearch_gene_search_index_query_mapper($arguments) {
   $queries = [];
-  $organism = isset($arguments['organism']) ? $arguments['organism'] : NULL;
-  $term = isset($arguments['search_term']) ? $arguments['search_term'] : NULL;
+  $organism = isset($arguments['organism']) ? trim($arguments['organism']) : NULL;
+  $term = isset($arguments['search_term']) ? trim($arguments['search_term']) : NULL;
 
   if (!empty($organism)) {
     $organism_array = explode(' ', $organism);
@@ -162,7 +162,7 @@ function tripal_elasticsearch_gene_search_index_query_mapper($arguments) {
       ];
     }
     else {
-      $fields = ['_all'];
+      $fields = [];
     }
 
     $queries[] = [

--- a/includes/tripal_elasticsearch.indices.form.inc
+++ b/includes/tripal_elasticsearch.indices.form.inc
@@ -982,6 +982,7 @@ function tripal_elasticsearch_update_index($index) {
   }
 
   drupal_set_message("{$index} updating jobs have been dispatched successfully. Please run `drush cron` to process items in the queue.");
+  drupal_goto('admin/tripal/extension/tripal_elasticsearch/indices');
 }
 
 /**


### PR DESCRIPTION
Fixes issue #253 

The new ES version does not accept `_all` as an option for fields anymore. But it auto matches all if the fields array is empty.